### PR TITLE
feat: redirect to error page if id is invalid

### DIFF
--- a/js/project.js
+++ b/js/project.js
@@ -95,8 +95,12 @@ async function load() {
   try {
     const projects = await fetchProjects();
     const parsedProjects = parseProjects(projects);
-    renderProject(parsedProjects.project);
-    renderOtherProjects(parsedProjects.otherProjects);
+    if (parsedProjects.project == null) {
+      window.location.replace("/error-page");
+    } else {
+      renderProject(parsedProjects.project);
+      renderOtherProjects(parsedProjects.otherProjects);
+    }
   } catch (error) {
     const projectAndProjectsWrapper = document.getElementById(
       "project-and-projects-wrapper"


### PR DESCRIPTION
I added a conditional that checks if the id in the query string exists in the API response. If in the API response there is no project with the requested id, the page is redirected to the error page.

Example: https://deploy-preview-64--ironhack-mid-term-project-group-6.netlify.app/project-page?id=6

In the API response, there's no project with the uuid 6, and the page is redirected to the error page.